### PR TITLE
Proxy body if request does not have Content-Length header

### DIFF
--- a/src/main/java/io/muserver/murp/ReverseProxy.java
+++ b/src/main/java/io/muserver/murp/ReverseProxy.java
@@ -239,10 +239,10 @@ public class ReverseProxy implements MuHandler {
         for (Map.Entry<String, String> clientHeader : reqHeaders) {
             String key = clientHeader.getKey();
             String lowKey = key.toLowerCase();
+            hasContentLengthOrTransferEncoding |= lowKey.equals("content-length") || lowKey.equals("transfer-encoding");
             if (excludedHeaders.contains(lowKey) || customHopByHop.contains(lowKey)) {
                 continue;
             }
-            hasContentLengthOrTransferEncoding |= lowKey.equals("content-length") || lowKey.equals("transfer-encoding");
             targetRequest.header(key, clientHeader.getValue());
         }
 


### PR DESCRIPTION
Do not ignore Transfer-Encoding headers when determining
whether a request has a body that needs proxying.

The existing code was setting `hasContentLengthOrTransferEncoding`
after excluding the Transfer-Encoding header.