### PR TITLE
bug fix: upload file randomly broken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>io.muserver</groupId>
             <artifactId>mu-server</artifactId>
-            <version>1.0.6</version>
+            <version>2.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,31 +51,31 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.16</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.muserver</groupId>
             <artifactId>mu-server</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>2.2</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -87,19 +87,19 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>5.0.0-alpha.12</version>
+            <version>5.0.0-alpha.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
-            <version>5.0.0-alpha.12</version>
+            <version>5.0.0-alpha.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/muserver/murp/ReverseProxy.java
+++ b/src/main/java/io/muserver/murp/ReverseProxy.java
@@ -173,7 +173,15 @@ public class ReverseProxy implements MuHandler {
                                         @Override
                                         public void onDataReceived(ByteBuffer byteBuffer, DoneCallback doneCallback) {
                                             doneCallbacks.add(doneCallback);
-                                            subscriber.onNext(byteBuffer);
+
+                                            // bug fix : upload file random broken - (some of the bytes changed)
+                                            // clone the byteBuffer to avoid it's being modified after passing into subscriber.onNext()
+                                            int capacity = byteBuffer.remaining();
+                                            ByteBuffer copy = byteBuffer.isDirect() ? ByteBuffer.allocateDirect(capacity) : ByteBuffer.allocate(capacity);
+                                            copy.put(byteBuffer);
+                                            copy.rewind();
+
+                                            subscriber.onNext(copy);
                                         }
 
                                         @Override


### PR DESCRIPTION
When proxying request body, clone the body bytes to avoid bytes modification after passing to jdk http client. 