### PR TITLE
Close connection on 5xx error to avoid leaking exchanges on slow uploads

### DIFF
--- a/src/main/java/io/muserver/murp/ReverseProxy.java
+++ b/src/main/java/io/muserver/murp/ReverseProxy.java
@@ -453,6 +453,12 @@ public class ReverseProxy implements MuHandler {
                 final int status = (throwable instanceof TimeoutException) ? 504 : 500;
                 final String body = (throwable instanceof TimeoutException) ? "504 Gateway Timeout" : "500 Internal Server Error";
                 clientResponse.status(status);
+                // The target failed before we finished proxying. If the client is still uploading the request body
+                // (e.g. a slow/large PUT) the request never reaches an end state, so the exchange would stay
+                // IN_PROGRESS and leak in MuServer's activeRequests forever. Sending "Connection: close" makes
+                // MuServer close the connection once this response is sent, which cancels the in-flight request
+                // and lets the exchange complete.
+                clientResponse.headers().set(HeaderNames.CONNECTION, HeaderValues.CLOSE);
                 asyncHandle.write(Mutils.toByteBuffer(body));
                 asyncHandle.complete();
 

--- a/src/test/java/io/muserver/murp/ReverseProxyTest.java
+++ b/src/test/java/io/muserver/murp/ReverseProxyTest.java
@@ -663,6 +663,58 @@ public class ReverseProxyTest {
 
     }
 
+    /**
+     * Reproduces the leaked-exchange bug: when the target never responds (or dies) while the client is still
+     * uploading a request body, murp sends an error response (504/500) but the client-&gt;murp request is still
+     * in RECEIVING_BODY. Because muserver only ends an exchange once BOTH the request and response reach an end
+     * state, the exchange stays IN_PROGRESS and the request lingers forever in {@code stats().activeRequests()}.
+     *
+     * <p>The fix is for murp to set {@code Connection: close} on the error response so that muserver's
+     * HttpServerKeepAliveHandler closes the channel once the response is sent. That close triggers
+     * {@code onConnectionEnded} -&gt; {@code request.onCancelled(CLIENT_DISCONNECTED)}, moving the request to
+     * ERRORED so the exchange ends and is removed from activeRequests.</p>
+     */
+    @Test
+    public void errorResponseWhileClientStillUploadingDoesNotLeakTheExchange() throws Exception {
+
+        // target that accepts the connection but never produces a response, so murp's total timeout fires
+        // while the client is still uploading its (deliberately incomplete) request body.
+        MuServer targetServer = httpServer()
+            .addHandler((request, response) -> {
+                request.handleAsync(); // take over but never complete - the target "hangs" / never replies
+                return true;
+            })
+            .start();
+
+        MuServer reverseProxyServer = httpServer()
+            .addHandler(reverseProxy()
+                .withUriMapper(UriMapper.toDomain(targetServer.uri()))
+                .withTotalTimeout(500, TimeUnit.MILLISECONDS)
+            )
+            .start();
+
+        // raw client so we fully control the upload: send headers + part of the body, then keep the socket
+        // open without ever sending the rest (simulating a slow / never-finishing PUT upload).
+        try (RawClient rawClient = RawClient.create(reverseProxyServer.uri())) {
+            rawClient.sendStartLine("PUT", "/upload")
+                .sendHeader("host", reverseProxyServer.uri().getAuthority())
+                .sendHeader("content-length", "1000000") // promise a big body...
+                .endHeaders()
+                .sendUTF8("only-a-little-bit-of-the-body") // ...but only ever send a fraction of it
+                .flushRequest();
+
+            // murp's total timeout fires and an error status is returned to the client
+            assertEventually(rawClient::responseString, containsString(" 504"));
+
+            // the request must not be left hanging around in the reverse proxy's active requests once the
+            // error response has been sent - otherwise long-running uploads leak exchanges indefinitely.
+            assertEventually(() -> reverseProxyServer.stats().activeRequests(), is(empty()));
+        } finally {
+            targetServer.stop();
+            reverseProxyServer.stop();
+        }
+    }
+
     @Test
     public void itCanProxyPieceByPieceWithProxyListener() throws InterruptedException, IOException {
         String m1 = StringUtils.randomAsciiStringOfLength(20000);


### PR DESCRIPTION
When a target failed before sending a response (target died or timed out), murp set a 500/504 status, wrote the body, and called asyncHandle.complete(). If the client was still uploading the request body at that point (e.g. a slow or large PUT), the request stayed in RECEIVING_BODY and never reached an end state.

MuServer only ends an exchange once BOTH the request and response are in an end state, so the exchange stayed IN_PROGRESS and the request lingered in stats().activeRequests() until the client finished uploading - which for long-running uploads could be hours or days. We observed many such PUTs stuck for days.

Setting "Connection: close" on the error response makes MuServer's HttpServerKeepAliveHandler close the channel once the response is sent. That triggers onConnectionEnded -> request.onCancelled(CLIENT_DISCONNECTED), moving the request to ERRORED so the exchange completes and is released. This mirrors what MuServer itself does for unrecoverable HTTP/1.1 errors in HttpExchange.onException.

The sibling branch (target dies after the response has started streaming) already calls asyncHandle.complete(throwable), which routes through onException and cancels the request, so it does not leak and needs no change.